### PR TITLE
Fixes errors from users landing on pages when they haven't added children

### DIFF
--- a/app/controllers/residential_address_controller.rb
+++ b/app/controllers/residential_address_controller.rb
@@ -1,6 +1,7 @@
 class ResidentialAddressController < FormsController
   def edit
     if current_household.children.count.zero?
+      flash[:errors] = [I18n.t('validations.please_add_student')]
       redirect_to(children_steps_path)
       return
     end

--- a/app/controllers/residential_address_controller.rb
+++ b/app/controllers/residential_address_controller.rb
@@ -1,2 +1,9 @@
 class ResidentialAddressController < FormsController
+  def edit
+    if current_household.children.count.zero?
+      redirect_to(children_steps_path)
+      return
+    end
+    super
+  end
 end

--- a/app/controllers/success_controller.rb
+++ b/app/controllers/success_controller.rb
@@ -1,4 +1,13 @@
 class SuccessController < FormsController
+  def edit
+    if current_household.children.count.zero?
+      flash[:errors] = [I18n.t('validations.please_add_student')]
+      redirect_to(children_steps_path)
+      return
+    end
+    super
+  end
+
   def update
     @form = form_class.new(current_household, form_params)
     if @form.valid?

--- a/spec/controllers/residential_address_controller_spec.rb
+++ b/spec/controllers/residential_address_controller_spec.rb
@@ -1,6 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe ResidentialAddressController do
-  it_behaves_like 'form controller base behavior', Household.create({ is_eligible: :yes })
+  it_behaves_like 'form controller base behavior', Household.create({ is_eligible: :yes }), true
   it_behaves_like 'form controller always shows'
+
+  context 'when no children have been set up' do
+    before do
+      household = Household.create({ is_eligible: :yes })
+      session[:current_household_id] = household.id
+    end
+
+    describe '#edit' do
+      it 'redirects to the add children screen' do
+        get :edit, params: { locale: I18n.default_locale }
+
+        expect(response.code).to eq '302'
+      end
+    end
+  end
 end

--- a/spec/controllers/success_controller_spec.rb
+++ b/spec/controllers/success_controller_spec.rb
@@ -2,4 +2,19 @@ require 'rails_helper'
 
 RSpec.describe SuccessController do
   it_behaves_like 'form controller always shows'
+
+  context 'when no children have been set up' do
+    before do
+      household = Household.create({ is_eligible: :yes })
+      session[:current_household_id] = household.id
+    end
+
+    describe '#edit' do
+      it 'redirects to the add children screen' do
+        get :edit, params: { locale: I18n.default_locale }
+
+        expect(response.code).to eq '302'
+      end
+    end
+  end
 end

--- a/spec/support/forms_controller_base_behavior.rb
+++ b/spec/support/forms_controller_base_behavior.rb
@@ -1,8 +1,11 @@
 require 'rails_helper'
 
-RSpec.shared_examples_for 'form controller base behavior' do |household|
+RSpec.shared_examples_for 'form controller base behavior' do |household, has_children = false|
   context 'with session' do
     before do
+      if has_children
+        household.children = [build(:child)]
+      end
       session[:current_household_id] = household.id
     end
 


### PR DESCRIPTION
For #172982788 

The application flow expects that pages after the "Add Children" page will operate in the context of having children added to the household. When that's not the case, a couple of the pages will 500 because they're relying on information from those children. This forces a redirect back to the add children page with an associated flash message if they end up in places they shouldn't be.

Validation Steps:
 - Start a new application and proceed until you are on the "Add a student" page.
 - Make sure the household has no students in the page
 - Change the URL from `/en/steps/children` to `/en/steps/residential-address`. You should see that you are back on the "Add a student" page with a message asking you to Please add a student.
 - Change the URL from `/en/steps/children` to `/en/steps/success` and you should see the same behavior as above

Background: This is likely happening from people moving into the application process, adding a student, hitting the back button to delete, but then hitting the forward button in their browser. 